### PR TITLE
Fix issue when mongo uri is replica set

### DIFF
--- a/lib/mongo_client.js
+++ b/lib/mongo_client.js
@@ -19,7 +19,8 @@ MongoClient.connect = function(url, options, callback) {
   debug('connecting %s%s', url.host, url.pathname);
 
   var dbname = url.pathname.replace(/^\//, '');
-  return new Db(dbname, server).open(callback);
+  dbname = dbname.split("/");
+  return new Db(dbname[dbname.length-1], server).open(callback);
 };
 
 MongoClient._persist = persist;


### PR DESCRIPTION
When mongo uri is a replicaset mock fails with error:
**Unhandled rejection Error: database names cannot contain the character '.'**
This pull request solve it doing a split by "/" and selecting the last element as database name.
